### PR TITLE
Remove compiler syntax warnings for elixir 1.4

### DIFF
--- a/lib/parallel.ex
+++ b/lib/parallel.ex
@@ -47,7 +47,7 @@ defmodule Parallel do
   def worker(fun) do
     receive do
       {ref, sender, item} ->
-        send(sender, {ref, self, fun.(item)})
+        send(sender, {ref, self(), fun.(item)})
         worker(fun)
       :exit ->
         :ok

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Parallel.Mixfile do
   def project do
     [ app: :parallel,
       version: "0.0.1",
-      deps: deps ]
+      deps: deps() ]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
Elixir 1.4 requires parentheses in function calls, else warnings are displayed. This PR fixes the parentheses.