### PR TITLE
Avoid Warnings in Elixir 1.4 of Missing Parentheses

### DIFF
--- a/lib/parallel.ex
+++ b/lib/parallel.ex
@@ -47,7 +47,7 @@ defmodule Parallel do
   def worker(fun) do
     receive do
       {ref, sender, item} ->
-        send(sender, {ref, self, fun.(item)})
+        send(sender, {ref, self(), fun.(item)})
         worker(fun)
       :exit ->
         :ok

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Parallel.Mixfile do
   def project do
     [ app: :parallel,
       version: "0.0.1",
-      deps: deps ]
+      deps: deps() ]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
To avoid

`warning: variable "self" does not exist and is being expanded to "self()", please use parentheses to remove the ambiguity or change the variable name`

and similiar warnings!